### PR TITLE
Removed download of golint from test script for Go versions different than Go 1.5 and Go 1.6

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -13,7 +13,9 @@ TEST_SUITE=$1
 if [[ $TEST_SUITE == "unit" ]]; then
 	go get github.com/axw/gocov/gocov
 	go get github.com/mattn/goveralls
-	go get -u github.com/golang/lint/golint
+	if [[ `go version` =~ go1.5  ||  `go version` =~ go1.6 ]]; then
+	    go get -u github.com/golang/lint/golint
+	fi
 	go get golang.org/x/tools/cmd/vet
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/smartystreets/goconvey/convey


### PR DESCRIPTION
golint has dropped support for Go 1.4.2, and now requires Go 1.5 or Go 1.6. Test script would download golint, removing the download for Go versions different than Go 1.5 and Go 1.6 allows testing for earlier versions of Go.