### PR TITLE
Fixed #20 and #21

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -138,7 +138,7 @@ func GetConfigItem(config interface{}, name string) (interface{}, error) {
 
 // GetConfigItems returns map to values of multiple  configuration items defined in Global Config or Metrics Config
 // Notes: GetConfigItems() will be helpful to access and and get multiple configuration items' values, both in GetMetricTypes() and CollectMetrics()
-func GetConfigItems(config interface{}, names []string) (map[string]interface{}, error) {
+func GetConfigItems(config interface{}, names ...string) (map[string]interface{}, error) {
 
 	switch config.(type) {
 	case plugin.PluginConfigType:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -370,7 +370,7 @@ func TestConfigItems(t *testing.T) {
 			cfg.AddItem("dummy_int", ctypes.ConfigValueInt{Value: dummy_int})
 			cfg.AddItem("dummy_float", ctypes.ConfigValueFloat{Value: dummy_float})
 
-			result, err := GetConfigItems(cfg, names)
+			result, err := GetConfigItems(cfg, names...)
 			So(err, ShouldBeNil)
 			for _, name := range names {
 				So(result[name], ShouldNotBeEmpty)
@@ -389,7 +389,7 @@ func TestConfigItems(t *testing.T) {
 			metric := plugin.PluginMetricType{}
 			metric.Config_ = config
 
-			result, err := GetConfigItems(metric, names)
+			result, err := GetConfigItems(metric, names...)
 			So(err, ShouldBeNil)
 			for _, name := range names {
 				So(result[name], ShouldNotBeEmpty)
@@ -399,7 +399,7 @@ func TestConfigItems(t *testing.T) {
 
 	Convey("Try to get values of items from invalid config (unsupported type)", t, func() {
 		invalid_cfg := []string{"invalid", "config", "source"}
-		result, err := GetConfigItems(invalid_cfg, names)
+		result, err := GetConfigItems(invalid_cfg, names...)
 		So(err, ShouldNotBeNil)
 		So(result, ShouldBeNil)
 	})

--- a/ns/namespace.go
+++ b/ns/namespace.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 
 	"github.com/oleiade/reflections"
+
+	"github.com/intelsdi-x/snap-plugin-utilities/str"
 )
 
 type FlagFunc (func(nsPath string, itemKind reflect.Type) bool)
@@ -320,7 +322,9 @@ func fromCompositeObject(object interface{}, current string, namespace *[]string
 	val := reflect.Indirect(reflect.ValueOf(object))
 	saneAppendNs := func() {
 		if current != "" {
-			*namespace = append(*namespace, current)
+			if !str.Contains(*namespace, current) {
+				*namespace = append(*namespace, current)
+			}
 		}
 	}
 	safeExtendNs := func(part string) string {


### PR DESCRIPTION
- fixed #20, namespace is build with checking for already existing items
- changed config.GetConfigItems() signature to accept variadic arguments instead of slice