### PR TITLE
Handle pointers in GetValueByNamespace()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Vendored deps
+Godeps/_workspace/**
+vendor/
+
+# Misc
+.DS_Store
+.idea
+.vagrant/
+tmp/
+*.tmp
+*.swp
+profile.cov

--- a/ns/namespace.go
+++ b/ns/namespace.go
@@ -142,6 +142,13 @@ func GetValueByNamespace(object interface{}, ns []string) interface{} {
 				if reflect.TypeOf(val.MapIndex(kval).Interface()).Kind() == reflect.Struct {
 					return GetValueByNamespace(val.MapIndex(kval).Interface(), ns[2:])
 				}
+			case reflect.Ptr:
+				val = reflect.ValueOf(val).Elem().Interface()
+				if len(ns) == 1 {
+					return val
+				} else {
+					return GetValueByNamespace(val, ns[1:])
+				}
 			default:
 				// last ns, return value found
 				if len(ns) == 1 {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -52,7 +52,7 @@ if [[ $TEST_SUITE == "unit" ]]; then
 	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
 	do
 		if ls $dir/*.go &> /dev/null; then
-	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		go test -v --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
 	    		if [ -f $dir/profile.tmp ]
 	    		then
 	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov


### PR DESCRIPTION
Prior to this PR, no tests existed for `GetValueByNamespace()`. Through some basic usage of this function, I found that `GetValueByNamespace()` also couldn't handle pointers. Specifically, this would happen:

```
  * /Users/roger/work/gocode/src/github.com/intelsdi-x/snap-plugin-utilities/ns/namespace_test.go
  Line 1318:
  Expected: '3.14'
  Actual:   '0xc820181948'
  (Should be equal)
```

This commit adds some test cases, and an additional case before the default case for handling type `reflect.Ptr`. If the type is a pointer, val is set to the value that the pointer points to. It then returns if `len(ns)` is 1, or goes deeper if the length of the namespace is greater than 1.

/cc @marcin-krolik 