### PR TITLE
ConvertDynamicElements added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - TEST=unit
 before_install:
 - go get github.com/tools/godep
-- go get github.com/intelsdi-x/snap
 - if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
 install:
 - export TMPDIR=$HOME/tmp

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,15 +1,43 @@
 {
-	"ImportPath": "github.com/intelsdi-x/snap-plugin-utilities",
-	"GoVersion": "go1.5",
-	"Deps": [
-        {
-            "ImportPath": "github.com/oleiade/reflections",
-            "Comment": "0.1.2-2-g632977f",
-            "Rev": "632977f98cd34d217c4b57d0840ec188b3d3dcaf"
-        },
-        {
-            "ImportPath": "github.com/vektra/errors",
-            "Rev": "c64d83aba85aa4392895aadeefabbd24e89f3580"
-        }
-	]
+  "ImportPath": "github.com/intelsdi-x/snap-plugin-utilities",
+  "GoVersion": "go1.5",
+  "Deps": [
+    {
+      "ImportPath": "github.com/intelsdi-x/snap/control/plugin",
+      "Comment": "v0.13.0-beta-77-g5c1177e",
+      "Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+    },
+    {
+      "ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
+      "Comment": "v0.13.0-beta-77-g5c1177e",
+      "Rev": "5c1177efc47eccc10dc459e3be44083372ea08c3"
+    },
+    {
+      "ImportPath": "github.com/oleiade/reflections",
+      "Comment": "0.1.2-2-g632977f",
+      "Rev": "632977f98cd34d217c4b57d0840ec188b3d3dcaf"
+    },
+    {
+      "ImportPath": "github.com/vektra/errors",
+      "Rev": "c64d83aba85aa4392895aadeefabbd24e89f3580"
+    },
+    {
+      "ImportPath": "github.com/Sirupsen/logrus",
+      "Comment": "v0.10.0-16-gcd7d1bb",
+      "Rev": "cd7d1bbe41066b6c1f19780f895901052150a575"
+    },
+    {
+      "ImportPath": "github.com/robfig/cron",
+      "Comment": "v1-16-g0f39cf7",
+      "Rev": "0f39cf7ebc65a602f45692f9894bd6a193faf8fa"
+    },
+    {
+      "ImportPath": "golang.org/x/sys/unix",
+      "Rev": "c8bc69bc2db9c57ccf979550bc69655df5039a8a"
+    },
+    {
+      "ImportPath": "gopkg.in/yaml.v2",
+      "Rev": "c1cd2254a6dd314c9d73c338c12688c9325d85c6"
+    }
+  ]
 }

--- a/config/config.go
+++ b/config/config.go
@@ -49,7 +49,7 @@ func getConfigItemValue(item ctypes.ConfigValue) (interface{}, error) {
 		break
 
 	default:
-		return nil, fmt.Errorf("Unsupported type of configuration item, type=%+v", item.Type())
+		return nil, fmt.Errorf("Unsupported type of configuration item, type=%v", item.Type())
 	}
 
 	return value, nil
@@ -59,11 +59,13 @@ func getConfigItemValue(item ctypes.ConfigValue) (interface{}, error) {
 // Notes: GetGlobalConfigItem() will be helpful to access and get configuration item's value in GetMetricTypes()
 func GetGlobalConfigItem(cfg plugin.ConfigType, name string) (interface{}, error) {
 
-	if item, ok := cfg.Table()[name]; ok {
-		return getConfigItemValue(item)
+	if cfg.ConfigDataNode != nil && len(cfg.Table()) > 0 {
+		if item, ok := cfg.Table()[name]; ok {
+			return getConfigItemValue(item)
+		}
 	}
 
-	return nil, fmt.Errorf("Cannot find %+v in Global Config", name)
+	return nil, fmt.Errorf("Cannot find %v in Global Config", name)
 }
 
 // GetGlobalConfigItems returns map to values of multiple configuration items defined in Plugin Global Config and specified in 'names' slice
@@ -72,16 +74,20 @@ func GetGlobalConfigItems(cfg plugin.ConfigType, names []string) (map[string]int
 	result := make(map[string]interface{})
 
 	for _, name := range names {
-		item, ok := cfg.Table()[name]
-		if !ok {
-			return nil, fmt.Errorf("Cannot find %+v in Global Config", name)
-		}
+		if cfg.ConfigDataNode != nil && len(cfg.Table()) > 0 {
+			item, ok := cfg.Table()[name]
+			if !ok {
+				return nil, fmt.Errorf("Cannot find %v in Global Config", name)
+			}
 
-		val, err := getConfigItemValue(item)
-		if err != nil {
-			return nil, err
+			val, err := getConfigItemValue(item)
+			if err != nil {
+				return nil, err
+			}
+			result[name] = val
+		} else {
+			return nil, fmt.Errorf("Cannot find %v in Global Config", name)
 		}
-		result[name] = val
 	}
 
 	return result, nil
@@ -91,12 +97,13 @@ func GetGlobalConfigItems(cfg plugin.ConfigType, names []string) (map[string]int
 // Notes: GetMetricConfigItem() will be helpful to access and get configuration item's value in CollectMetrics()
 // (Plugin Global Config is merged into Metric Config)
 func GetMetricConfigItem(metric plugin.MetricType, name string) (interface{}, error) {
-
-	if item, ok := metric.Config().Table()[name]; ok {
-		return getConfigItemValue(item)
+	if metric.Config() != nil && len(metric.Config().Table()) > 0 {
+		if item, ok := metric.Config().Table()[name]; ok {
+			return getConfigItemValue(item)
+		}
 	}
 
-	return nil, fmt.Errorf("Cannot find %+v in Metrics Config", name)
+	return nil, fmt.Errorf("Cannot find %v in Metrics Config", name)
 }
 
 // GetMetricConfigItems returns map to values of multiple configuration items defined in Metric Config and specified in 'names' slice
@@ -106,16 +113,20 @@ func GetMetricConfigItems(metric plugin.MetricType, names []string) (map[string]
 	result := make(map[string]interface{})
 
 	for _, name := range names {
-		item, ok := metric.Config().Table()[name]
-		if !ok {
-			return nil, fmt.Errorf("Cannot find %+v in Metrics Config", name)
-		}
+		if metric.Config() != nil && len(metric.Config().Table()) > 0 {
+			item, ok := metric.Config().Table()[name]
+			if !ok {
+				return nil, fmt.Errorf("Cannot find %v in Metrics Config", name)
+			}
 
-		val, err := getConfigItemValue(item)
-		if err != nil {
-			return nil, err
+			val, err := getConfigItemValue(item)
+			if err != nil {
+				return nil, err
+			}
+			result[name] = val
+		} else {
+			return nil, fmt.Errorf("Cannot find %v in Metrics Config", name)
 		}
-		result[name] = val
 	}
 
 	return result, nil

--- a/mts/mts.go
+++ b/mts/mts.go
@@ -1,0 +1,60 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mts
+
+import (
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core"
+)
+
+// ConvertDynamicElements removes dynamic `NamespaceElements` from `core.Namespace`
+// and turn them into tags. Useful when metrics with unwanted namespace elements are gathered
+// like `/intel/mock/host1/foo`, `/intel/mock/host2/foo` ... `/intel/mock/hostN/foo`
+// where `hostN` is dynamic `NamespaceElement` (has Name) and one wants to publish them
+// as `/intel/mock/foo` with additional tags as like host_name: hostN
+func ConvertDynamicElements(metrics []plugin.MetricType) {
+	for j, metric := range metrics {
+		if isDynamic, indexes := metric.Namespace().IsDynamic(); isDynamic {
+			static := core.Namespace{}
+			tags := metric.Tags()
+			if tags == nil {
+				tags = map[string]string{}
+			}
+			for i, nse := range metric.Namespace() {
+				if contains(indexes, i) {
+					tags[nse.Name] = nse.Value
+				} else {
+					static = append(static, nse)
+				}
+			}
+			metrics[j].Namespace_ = static
+			metrics[j].Tags_ = tags
+		}
+	}
+}
+
+func contains(slice []int, lookup int) bool {
+	for _, element := range slice {
+		if element == lookup {
+			return true
+		}
+	}
+	return false
+}

--- a/mts/mts_test.go
+++ b/mts/mts_test.go
@@ -1,0 +1,91 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+
+Copyright 2015 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mts
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/core"
+)
+
+func TestConvertDynamicElements(t *testing.T) {
+	Convey("Given list of metrics", t, func() {
+		metrics := []plugin.MetricType{
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "mock", "foo"),
+				Tags_:      map[string]string{},
+			},
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "mock").AddDynamicElement("foos", "foos contains many foo").AddStaticElement("bar"),
+				Tags_:      map[string]string{},
+			},
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "mock").AddDynamicElement("foos", "foos contains many foo").AddStaticElement("bar"),
+				Tags_:      map[string]string{core.STD_TAG_PLUGIN_RUNNING_ON: "127.0.0.1"},
+			},
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "mock").AddDynamicElement("foos", "foos contains many foo").AddStaticElements("bar", "tar"),
+				Tags_:      map[string]string{},
+			},
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel").AddDynamicElement("foos", "foos contains many foo").AddStaticElements("bar", "tar"),
+				Tags_:      map[string]string{},
+			},
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel").AddDynamicElement("foos", "foos contains many foo").AddDynamicElement("bars", "bars contains many bar").AddStaticElement("tar"),
+				Tags_:      map[string]string{},
+			},
+		}
+
+		Convey("When conversion of dynamic namespaces is triggered", func() {
+			mockCollectorActionOnDynamicMetric(metrics)
+			ConvertDynamicElements(metrics)
+
+			Convey("Then metric namespaces are converted to static and proper tags are added", func() {
+				So(metrics[0].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "mock", "foo").String())
+				So(metrics[0].Tags_, ShouldResemble, map[string]string{})
+				So(metrics[1].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "mock", "bar").String())
+				So(metrics[1].Tags_, ShouldResemble, map[string]string{"foos": "value_1_2"})
+				So(metrics[2].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "mock", "bar").String())
+				So(metrics[2].Tags_, ShouldResemble, map[string]string{"foos": "value_2_2", core.STD_TAG_PLUGIN_RUNNING_ON: "127.0.0.1"})
+				So(metrics[3].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "mock", "bar", "tar").String())
+				So(metrics[3].Tags_, ShouldResemble, map[string]string{"foos": "value_3_2"})
+				So(metrics[4].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "bar", "tar").String())
+				So(metrics[4].Tags_, ShouldResemble, map[string]string{"foos": "value_4_1"})
+				So(metrics[5].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "tar").String())
+				So(metrics[5].Tags_, ShouldResemble, map[string]string{"foos": "value_5_1", "bars": "value_5_2"})
+			})
+		})
+	})
+}
+
+func mockCollectorActionOnDynamicMetric(metrics []plugin.MetricType) {
+	for i, metric := range metrics {
+		if isDynamic, indexes := metric.Namespace().IsDynamic(); isDynamic {
+			for _, index := range indexes {
+				metrics[i].Namespace()[index].Value = fmt.Sprintf("value_%d_%d", i, index)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added function to handle dynamic `NamespaceElement` at processor/publisher level. Dynamic elements are removed from `core.Namespace` and turned into tags.