### PR TITLE
Remove everything after the first coma from the tag

### DIFF
--- a/ns/namespace.go
+++ b/ns/namespace.go
@@ -112,8 +112,10 @@ func GetValueByNamespace(object interface{}, ns []string) interface{} {
 			fmt.Printf("Could not find tag for field{%s}\n", field)
 			return nil
 		}
+
 		// remove omitempty from tag
-		tag = strings.Replace(tag, ",omitempty", "", -1)
+		tag = strings.Split(tag, ",")[0]
+
 		if tag == current {
 			val, err := reflections.GetField(object, field)
 			if err != nil {


### PR DESCRIPTION
Currently we it's removing ",omitempty" only. I found out that some people use ", omitempty" so the tag wouldn't match the `current` element.