### PR TITLE
Don't emit non JSON on stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: required
 language: go
 go:
-- 1.5.4
-- 1.6.2
+- 1.8.4
+- 1.9.1
 env:
   global:
     - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/snap-plugin-utilities

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TEST?="unit"
+
 default:
 	$(MAKE) deps
 	$(MAKE) all

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -48,7 +48,7 @@ func init() {
 		logFile, err = os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
 		if err != nil {
 			// writing non-JSON to stdout is forbidden in Snap plugin init
-			os.StdErr.WriteString("Logging to stderr")
+			os.Stderr.WriteString("Logging to stderr")
 		}
 	}
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -20,7 +20,6 @@ limitations under the License.
 package logger
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -48,7 +47,8 @@ func init() {
 	if logFile == nil {
 		logFile, err = os.OpenFile(fname, os.O_APPEND|os.O_CREATE|os.O_RDWR, 0666)
 		if err != nil {
-			fmt.Println("Logging to stderr")
+			// writing non-JSON to stdout is forbidden in Snap plugin init
+			os.StdErr.WriteString("Logging to stderr")
 		}
 	}
 


### PR DESCRIPTION
 Fixes #38

## What
Remove a `fmt.Println` from the logger package's `init`

## Why
Later versions of Snap disallow any non-JSON strings to be emitted by plugins during the plugin load.

## What else
Sane default for `make test` (will run "unit" suite)