### PR TITLE
Added some nil-checks to prevent panics in GetStructValueByNamespace()

### DIFF
--- a/ns/namespace.go
+++ b/ns/namespace.go
@@ -184,14 +184,25 @@ func GetStructValueByNamespace(object interface{}, ns []string) interface{} {
 			// handling of special cases for slice and map
 			switch reflect.TypeOf(val).Kind() {
 			case reflect.Slice:
+				if len(ns) < 2 {
+					return nil
+				}
 				idx, _ := strconv.Atoi(ns[1])
+
 				val := reflect.ValueOf(val)
+				if val.IsNil() || val.Len() == 0 {
+					return nil
+				}
+
 				if val.Index(idx).Kind() == reflect.Struct {
 					return GetStructValueByNamespace(val.Index(idx).Interface(), ns[2:])
 				} else {
 					return val.Index(idx).Interface()
 				}
 			case reflect.Map:
+				if len(ns) < 2 {
+					return nil
+				}
 				key := ns[1]
 
 				if vi, ok := val.(map[string]uint64); ok {
@@ -199,7 +210,12 @@ func GetStructValueByNamespace(object interface{}, ns []string) interface{} {
 				}
 
 				val := reflect.ValueOf(val)
+				if val.IsNil() || val.Len() == 0 {
+					return nil
+				}
+
 				kval := reflect.ValueOf(key)
+
 				if reflect.TypeOf(val.MapIndex(kval).Interface()).Kind() == reflect.Struct {
 					return GetStructValueByNamespace(val.MapIndex(kval).Interface(), ns[2:])
 				}

--- a/ns/namespace_test.go
+++ b/ns/namespace_test.go
@@ -1291,12 +1291,18 @@ func TestGetValueByNamespace(t *testing.T) {
 			DataThree *bar     `json:"data_three,omitempty"`
 		}
 		m := struct {
-			ID      string      `json:"id"`
-			Invalid interface{} `json:"invalid"`
-			Data    *foo        `json:"data"`
+			ID         string      `json:"id"`
+			InvalidOne interface{} `json:"invalid_one"`
+			InvalidTwo struct {
+				NestedMap map[string]int `json:"nested_map"`
+			} `json:"invalid_two"`
+			InvalidThree struct {
+				NestedSlice []int `json:"nested_slice"`
+			} `json:"invalid_three"`
+			Data *foo `json:"data"`
 		}{
-			ID:      "FooID-12345",
-			Invalid: new(interface{}),
+			ID:         "FooID-12345",
+			InvalidOne: new(interface{}),
 			Data: &foo{
 				DataOne: 127,
 				DataTwo: dataTwo,
@@ -1325,7 +1331,17 @@ func TestGetValueByNamespace(t *testing.T) {
 		})
 
 		Convey("Should not attempt to interface a zero value", func() {
-			So(func() { GetValueByNamespace(m, []string{"invalid"}) }, ShouldNotPanic)
+			So(func() { GetValueByNamespace(m, []string{"invalid_one"}) }, ShouldNotPanic)
+		})
+
+		Convey("Should not fail on an empty map", func() {
+			So(func() { GetValueByNamespace(m, []string{"invalid_two", "nested_map"}) }, ShouldNotPanic)
+			So(func() { GetValueByNamespace(m, []string{"invalid_two", "nested_map", "missing_key"}) }, ShouldNotPanic)
+		})
+
+		Convey("Should not fail on an empty slice", func() {
+			So(func() { GetValueByNamespace(m, []string{"invalid_three", "nested_slice"}) }, ShouldNotPanic)
+			So(func() { GetValueByNamespace(m, []string{"invalid_three", "nested_slice", "0"}) }, ShouldNotPanic)
 		})
 	})
 

--- a/ns/namespace_test.go
+++ b/ns/namespace_test.go
@@ -29,7 +29,6 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"fmt"
 	_ "fmt"
 )
 
@@ -358,7 +357,6 @@ func TestSimpleStruct(t *testing.T) {
 
 func TestComplexStruct(t *testing.T) {
 	Convey("Given composition of structs", t, func() {
-		fmt.Printf("\nTU\n")
 		Foo := struct {
 			Bar struct {
 				Qaz int


### PR DESCRIPTION
Added some nil-checks to prevent panics in GetStructValueByNamespace() along with new test cases for `ns` demonstrating where the current code crashes